### PR TITLE
Update CMakeList.txt for simpleCUFFT_callback and GLES samplesTegra samples cmake transition

### DIFF
--- a/Samples/4_CUDA_Libraries/simpleCUFFT_callback/CMakeLists.txt
+++ b/Samples/4_CUDA_Libraries/simpleCUFFT_callback/CMakeLists.txt
@@ -28,7 +28,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set_target_properties(simpleCUFFT_callback PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
     target_link_libraries(simpleCUFFT_callback PRIVATE
-        CUDA::cufft
+        CUDA::cufft_static
+        culibos
     )
 else()
     message(STATUS "Will not build sample simpleCUFFT_callback - requires Linux OS")

--- a/Samples/8_Platform_Specific/Tegra/fluidsGLES/CMakeLists.txt
+++ b/Samples/8_Platform_Specific/Tegra/fluidsGLES/CMakeLists.txt
@@ -47,6 +47,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
                     ${X11_LIBRARIES}
                     ${OPENGL_LIBRARIES}
                 )
+
+                # Copy the .glsl files to the output directory
+                add_custom_command(TARGET fluidsGLES POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${CMAKE_CURRENT_SOURCE_DIR}/mesh.frag.glsl
+                    ${CMAKE_CURRENT_SOURCE_DIR}/mesh.vert.glsl
+                    ${CMAKE_CURRENT_BINARY_DIR}
+                )
             else()
                 message(STATUS "X11 libraries not found - will not build sample 'fluidsGLES'")
             endif()

--- a/Samples/8_Platform_Specific/Tegra/simpleGLES/CMakeLists.txt
+++ b/Samples/8_Platform_Specific/Tegra/simpleGLES/CMakeLists.txt
@@ -45,6 +45,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
                     ${X11_LIBRARIES}
                     ${OPENGL_LIBRARIES}
                 )
+
+                # Copy the .glsl files to the output directory
+                add_custom_command(TARGET simpleGLES POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${CMAKE_CURRENT_SOURCE_DIR}/mesh.frag.glsl
+                    ${CMAKE_CURRENT_SOURCE_DIR}/mesh.vert.glsl
+                    ${CMAKE_CURRENT_BINARY_DIR}
+                )
+
             else()
                 message(STATUS "X11 libraries not found - will not build sample 'simpleGLES'")
             endif()

--- a/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput/CMakeLists.txt
+++ b/Samples/8_Platform_Specific/Tegra/simpleGLES_EGLOutput/CMakeLists.txt
@@ -52,6 +52,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
                     ${OPENGL_LIBRARIES}
                     ${DRM_LIB}
                 )
+
+                # Copy the .glsl files to the output directory
+                add_custom_command(TARGET simpleGLES_EGLOutput POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${CMAKE_CURRENT_SOURCE_DIR}/mesh.frag.glsl
+                    ${CMAKE_CURRENT_SOURCE_DIR}/mesh.vert.glsl
+                    ${CMAKE_CURRENT_BINARY_DIR}
+                )
             else()
                 message(STATUS "X11 libraries not found - will not build sample 'simpleGLES_EGLOutput'")
             endif()


### PR DESCRIPTION
1. Need to use cufft_static and culibos instead of CUDA::cufft for simpleCUFFT_callback - Bug 5028391
2. Copy .glsl files for GLES sample execution - Bug 5072083